### PR TITLE
Use openssl before sending rsa data to keytool

### DIFF
--- a/lib/android_apk.rb
+++ b/lib/android_apk.rb
@@ -309,7 +309,13 @@ class AndroidApk
     apk.verified = exit_status.success?
 
     if !exit_status.success? || certs_hunk.nil?
-      # Use a previous method as a fallback because apksigner cannot get a signature from an non installable apk
+      # For RSA or DSA encryption
+      print_certs_command = "openssl pkcs7 -inform DER -in <(unzip -p #{filepath.shellescape} META-INF/*.RSA META-INF/*.DSA) -print_certs | keytool -printcert | grep SHA1:"
+      certs_hunk, _, exit_status = Open3.capture3(print_certs_command)
+    end
+
+    if !exit_status.success? || certs_hunk.nil?
+      # Use a previous method as a fallback just in case
       print_certs_command = "unzip -p #{filepath.shellescape} META-INF/*.RSA META-INF/*.DSA | keytool -printcert | grep SHA1:"
       certs_hunk, _, exit_status = Open3.capture3(print_certs_command)
     end


### PR DESCRIPTION
It sounds the current fallback does not work for some of apks unfortunately...