### PR TITLE
Fixed no signature issue for installable apks but invalid jar sign

### DIFF
--- a/lib/android_apk.rb
+++ b/lib/android_apk.rb
@@ -309,7 +309,13 @@ class AndroidApk
     apk.verified = exit_status.success?
 
     if !exit_status.success? || certs_hunk.nil?
-      # Use a previous method as a fallback because apksigner cannot get a signature from an non installable apk
+      # For RSA or DSA encryption
+      print_certs_command = "openssl pkcs7 -inform DER -in <(unzip -p #{filepath.shellescape} META-INF/*.RSA META-INF/*.DSA) -print_certs | keytool -printcert | grep SHA1:"
+      certs_hunk, _, exit_status = Open3.capture3(print_certs_command)
+    end
+
+    if !exit_status.success? || certs_hunk.nil?
+      # Use a previous method as a fallback just in case
       print_certs_command = "unzip -p #{filepath.shellescape} META-INF/*.RSA META-INF/*.DSA | keytool -printcert | grep SHA1:"
       certs_hunk, _, exit_status = Open3.capture3(print_certs_command)
     end

--- a/lib/android_apk.rb
+++ b/lib/android_apk.rb
@@ -323,6 +323,8 @@ class AndroidApk
     if exit_status.success? && !certs_hunk.nil?
       signatures = certs_hunk.scan(/(?:[0-9a-zA-Z]{2}:?){20}/)
       apk.signature = signatures[0].delete(":").downcase if signatures.length == 1
+    else
+      apk.signature = nil # make sure being nil
     end
   end
 

--- a/lib/android_apk.rb
+++ b/lib/android_apk.rb
@@ -310,7 +310,7 @@ class AndroidApk
 
     if !exit_status.success? || certs_hunk.nil?
       # For RSA or DSA encryption
-      print_certs_command = "openssl pkcs7 -inform DER -in <(unzip -p #{filepath.shellescape} META-INF/*.RSA META-INF/*.DSA) -print_certs | keytool -printcert | grep SHA1:"
+      print_certs_command = "unzip -p #{filepath.shellescape} META-INF/*.RSA META-INF/*.DSA | openssl pkcs7 -inform DER -text -print_certs | keytool -printcert | grep SHA1:"
       certs_hunk, _, exit_status = Open3.capture3(print_certs_command)
     end
 


### PR DESCRIPTION
It sounds some of apks could not print their signatures by executing `unzip -p #{filepath.shellescape} META-INF/*.RSA META-INF/*.DSA | keytool -printcert`.
We should assume the format of stored RSA and DSA files may be pkcs7 and convert it to pem format.
FYI, I couldn't create such apks for testing from the scratch 🤷‍♂ but confirmed this worked using one real sample.