### PR TITLE
Fixed an illegal encoding error that happened through aapt outputs

### DIFF
--- a/lib/android_apk.rb
+++ b/lib/android_apk.rb
@@ -154,8 +154,8 @@ class AndroidApk
     apk.target_sdk_version = vars["targetSdkVersion"]
 
     # icons and labels
-    apk.icons = {} # old
-    apk.labels = {}
+    apk.icons = Hash.new # old
+    apk.labels = Hash.new
 
     vars.each_key do |k|
       if (m = k.match(/\Aapplication-icon-(\d+)\z/))
@@ -350,7 +350,7 @@ class AndroidApk
   # @param [String, nil] results output of aapt command. this may be multi lines.
   # @return [Hash, nil] return nil if (see str) is nil. Otherwise the parsed hash will be returned.
   def self._parse_aapt(results)
-    vars = {}
+    vars = Hash.new
     results.split("\n").each do |line|
       key, value = _parse_line(line)
       next if key.nil?

--- a/lib/android_apk.rb
+++ b/lib/android_apk.rb
@@ -154,8 +154,8 @@ class AndroidApk
     apk.target_sdk_version = vars["targetSdkVersion"]
 
     # icons and labels
-    apk.icons = Hash.new # old
-    apk.labels = Hash.new
+    apk.icons = ({}) # old
+    apk.labels = ({})
 
     vars.each_key do |k|
       if (m = k.match(/\Aapplication-icon-(\d+)\z/))
@@ -350,7 +350,7 @@ class AndroidApk
   # @param [String, nil] results output of aapt command. this may be multi lines.
   # @return [Hash, nil] return nil if (see str) is nil. Otherwise the parsed hash will be returned.
   def self._parse_aapt(results)
-    vars = Hash.new
+    vars = {}
     results.split("\n").each do |line|
       key, value = _parse_line(line)
       next if key.nil?

--- a/lib/android_apk/resource_finder.rb
+++ b/lib/android_apk/resource_finder.rb
@@ -7,21 +7,24 @@ class AndroidApk
       # @param default_icon_path [String, NilClass]
       # @return [Hash] keys are dpi human readable names, values are png file paths that are relative
       def resolve_icons_in_arsc(apk_filepath:, default_icon_path:)
-        return {} if default_icon_path.nil? || default_icon_path.empty?
+        return Hash.new if default_icon_path.nil? || default_icon_path.empty?
 
-        results = `aapt dump --values resources #{apk_filepath.shellescape} 2>&1`
-        if $?.exitstatus != 0 or results.index("ERROR: dump failed")
-          return {}
-        end
+        stdout = dump_resource_values(apk_filepath: apk_filepath) or return Hash.new
 
-        lines = results.split("\n")
+        lines = stdout.scrub.split("\n")
 
-        value_index = lines.index { |line| line.index(default_icon_path) } or return {}
-        resource_name = lines[value_index - 1].split(":")[1] or return {} # e.g. mipmap/ic_launcher
+        # Find the resource address line by the real resource path in the apk file.
+        #
+        #     resource ... <resource_name>: ... (l blocks)
+        #       ... "<default_icon_path>"
+        value_index = lines.index { |line| line.index(default_icon_path) } or return Hash.new
+
+        # resource_name never contain ':'
+        resource_name = lines[value_index - 1].split(":")[1] or return Hash.new # e.g. mipmap/ic_launcher
 
         start_index = lines.index { |line| line.index("spec resource ") && line.index(resource_name) }
 
-        config_hash = {}
+        config_hash = Hash.new
 
         lines = lines.drop(start_index + 1)
 
@@ -69,6 +72,12 @@ class AndroidApk
         end
 
         config_hash
+      end
+
+      def dump_resource_values(apk_filepath:)
+        stdout, _, status = Open3.capture3('aapt', 'dump', '--values', 'resources', apk_filepath)
+        # we just need only drawables/mipmaps, and they are utf-8(ascii) friendly.
+        stdout if status.success?
       end
     end
   end

--- a/lib/android_apk/resource_finder.rb
+++ b/lib/android_apk/resource_finder.rb
@@ -7,9 +7,9 @@ class AndroidApk
       # @param default_icon_path [String, NilClass]
       # @return [Hash] keys are dpi human readable names, values are png file paths that are relative
       def resolve_icons_in_arsc(apk_filepath:, default_icon_path:)
-        return Hash.new if default_icon_path.nil? || default_icon_path.empty?
+        return {} if default_icon_path.nil? || default_icon_path.empty?
 
-        stdout = dump_resource_values(apk_filepath: apk_filepath) or return Hash.new
+        stdout = dump_resource_values(apk_filepath: apk_filepath) or return {}
 
         lines = stdout.scrub.split("\n")
 
@@ -17,14 +17,14 @@ class AndroidApk
         #
         #     resource ... <resource_name>: ... (l blocks)
         #       ... "<default_icon_path>"
-        value_index = lines.index { |line| line.index(default_icon_path) } or return Hash.new
+        value_index = lines.index { |line| line.index(default_icon_path) } or return {}
 
         # resource_name never contain ':'
-        resource_name = lines[value_index - 1].split(":")[1] or return Hash.new # e.g. mipmap/ic_launcher
+        resource_name = lines[value_index - 1].split(":")[1] or return {} # e.g. mipmap/ic_launcher
 
         start_index = lines.index { |line| line.index("spec resource ") && line.index(resource_name) }
 
-        config_hash = Hash.new
+        config_hash = {}
 
         lines = lines.drop(start_index + 1)
 
@@ -75,7 +75,7 @@ class AndroidApk
       end
 
       def dump_resource_values(apk_filepath:)
-        stdout, _, status = Open3.capture3('aapt', 'dump', '--values', 'resources', apk_filepath)
+        stdout, _, status = Open3.capture3("aapt", "dump", "--values", "resources", apk_filepath)
         # we just need only drawables/mipmaps, and they are utf-8(ascii) friendly.
         stdout if status.success?
       end

--- a/spec/android_apk/resource_finder_spec.rb
+++ b/spec/android_apk/resource_finder_spec.rb
@@ -29,6 +29,29 @@ describe AndroidApk::ResourceFinder do
       end
     end
 
+    # emulate
+    context "sample.apk includes non UTF-8" do
+      let(:apk_filepath) { File.join(FIXTURE_DIR, "other", "sample.apk") }
+      let(:aapt_output) {
+        stdout = AndroidApk::ResourceFinder.dump_resource_values(apk_filepath: apk_filepath)
+        (stdout + "\xff").force_encoding("UTF-8")
+      }
+
+      before do
+        allow(AndroidApk::ResourceFinder).to receive(:dump_resource_values).and_return(aapt_output) # inject
+      end
+
+      it { expect { aapt_output.split('\n')}.to raise_error(ArgumentError, 'invalid byte sequence in UTF-8') }
+
+      it do
+        is_expected.to eq(
+                         "hdpi-v4" => "res/drawable-hdpi/ic_launcher.png",
+                         "mdpi-v4" => "res/drawable-mdpi/ic_launcher.png",
+                         "xhdpi-v4" => "res/drawable-xhdpi/ic_launcher.png"
+                       )
+      end
+    end
+
     context "resources" do
       let(:apk_filepath) { File.join(FIXTURE_DIR, "resources", apk_name) }
 
@@ -73,7 +96,7 @@ describe AndroidApk::ResourceFinder do
       context "noIcon" do
         let(:apk_name) { "apks-21/noIcon.apk" }
 
-        it { is_expected.to eq({}) }
+        it { is_expected.to eq(Hash.new) }
       end
 
       context "adaptiveIconWithPng" do
@@ -218,7 +241,7 @@ describe AndroidApk::ResourceFinder do
       context "noIcon" do
         let(:apk_name) { "apks-21/noIcon.apk" }
 
-        it { is_expected.to eq({}) }
+        it { is_expected.to eq(Hash.new) }
       end
 
       context "adaptiveIconWithPng" do

--- a/spec/android_apk/resource_finder_spec.rb
+++ b/spec/android_apk/resource_finder_spec.rb
@@ -32,23 +32,23 @@ describe AndroidApk::ResourceFinder do
     # emulate
     context "sample.apk includes non UTF-8" do
       let(:apk_filepath) { File.join(FIXTURE_DIR, "other", "sample.apk") }
-      let(:aapt_output) {
+      let(:aapt_output) do
         stdout = AndroidApk::ResourceFinder.dump_resource_values(apk_filepath: apk_filepath)
         (stdout + "\xff").force_encoding("UTF-8")
-      }
+      end
 
       before do
         allow(AndroidApk::ResourceFinder).to receive(:dump_resource_values).and_return(aapt_output) # inject
       end
 
-      it { expect { aapt_output.split('\n')}.to raise_error(ArgumentError, 'invalid byte sequence in UTF-8') }
+      it { expect { aapt_output.split('\n') }.to raise_error(ArgumentError, "invalid byte sequence in UTF-8") }
 
       it do
         is_expected.to eq(
-                         "hdpi-v4" => "res/drawable-hdpi/ic_launcher.png",
-                         "mdpi-v4" => "res/drawable-mdpi/ic_launcher.png",
-                         "xhdpi-v4" => "res/drawable-xhdpi/ic_launcher.png"
-                       )
+          "hdpi-v4" => "res/drawable-hdpi/ic_launcher.png",
+          "mdpi-v4" => "res/drawable-mdpi/ic_launcher.png",
+          "xhdpi-v4" => "res/drawable-xhdpi/ic_launcher.png"
+        )
       end
     end
 
@@ -96,7 +96,7 @@ describe AndroidApk::ResourceFinder do
       context "noIcon" do
         let(:apk_name) { "apks-21/noIcon.apk" }
 
-        it { is_expected.to eq(Hash.new) }
+        it { is_expected.to eq({}) }
       end
 
       context "adaptiveIconWithPng" do
@@ -241,7 +241,7 @@ describe AndroidApk::ResourceFinder do
       context "noIcon" do
         let(:apk_name) { "apks-21/noIcon.apk" }
 
-        it { is_expected.to eq(Hash.new) }
+        it { is_expected.to eq({}) }
       end
 
       context "adaptiveIconWithPng" do


### PR DESCRIPTION
`aapt dump --values resources` may contain non-utf8 characters. I couldn't reproduce such an apk so let me emulate it in specs.