### PR TITLE
Fix the order of AndroidApk#app_icons

### DIFF
--- a/lib/android_apk.rb
+++ b/lib/android_apk.rb
@@ -198,7 +198,7 @@ class AndroidApk
       when "anydpi"
         7_000 # Fallback of anydpi-v\d+
       when DEFAULT_RESOURCE_CONFIG
-        0 # Weakest
+        100 # Weakest
       else # Intermediate
         # We assume Google never release lower density than ldpi
         DPI_TO_NAME_MAP.key(name) || DPI_TO_NAME_MAP.keys.max

--- a/lib/android_apk.rb
+++ b/lib/android_apk.rb
@@ -193,13 +193,13 @@ class AndroidApk
     # [[highest dpi (or prior-level resolution), path], ...]
     sorted_paths = icon_path_hash.transform_keys do |name|
       case name
-      when DEFAULT_RESOURCE_CONFIG
-        10_000 # Primary
-      when "anydpi"
-        9_000 # Secondary
       when /anydpi-v(\d+)/
         8_000 + Regexp.last_match(1).to_i # Prioritized
-      else # Fallbacks
+      when "anydpi"
+        7_000 # Fallback of anydpi-v\d+
+      when DEFAULT_RESOURCE_CONFIG
+        0 # Weakest
+      else # Intermediate
         # We assume Google never release lower density than ldpi
         DPI_TO_NAME_MAP.key(name) || DPI_TO_NAME_MAP.keys.max
       end

--- a/spec/android_apk_spec.rb
+++ b/spec/android_apk_spec.rb
@@ -421,10 +421,6 @@ describe "AndroidApk" do
     it "returns an array ordered by dpi desc" do
       expect(app_icons.map(&:metadata)).to eq([
                                                 {
-                                                  dpi: 10_000,
-                                                  resource_path: "res/uF.xml"
-                                                },
-                                                {
                                                   dpi: 8026,
                                                   resource_path: "res/uF.xml"
                                                 },
@@ -447,6 +443,10 @@ describe "AndroidApk" do
                                                 {
                                                   dpi: 160,
                                                   resource_path: "res/u3.png"
+                                                },
+                                                {
+                                                  dpi: 100,
+                                                  resource_path: "res/uF.xml"
                                                 }
                                               ])
     end


### PR DESCRIPTION
- `(default)` is weakest 
  - `default` should be the default even for poor devices so it's chosen from the lowest one.
- dpi fallback was just wrong
  - Let's say we have `apidpi-v24` and `anydpi`, then devices lower than v24 use `anydpi`. The previous implementation was inverted.