### PR TITLE
Returns trusted signature lineage

### DIFF
--- a/lib/android_apk.rb
+++ b/lib/android_apk.rb
@@ -89,10 +89,10 @@ class AndroidApk
   end
 
   # Check whether or not this apk is verified
-  # @deprecated
+  # @deprecated this is the same to unsigned i.e. signature is nil
   # @return [Boolean] Return true if this apk is verified, otherwise false.
   def verified
-    (trusted_signature_lineage&.size || 0).positive?
+    !trusted_signature_lineage.empty?
   end
   alias verified? verified
 

--- a/lib/android_apk.rb
+++ b/lib/android_apk.rb
@@ -9,6 +9,7 @@ require "zip"
 require_relative "android_apk/app_icon"
 require_relative "android_apk/error"
 require_relative "android_apk/resource_finder"
+require_relative "android_apk/signature_verifier"
 require_relative "android_apk/xmltree"
 
 class AndroidApk
@@ -66,14 +67,9 @@ class AndroidApk
   # @return [String] Return Integer string which is defined in AndroidManifest.xml
   attr_accessor :target_sdk_version
 
-  # The SHA-1 signature of this apk
-  # @return [String, nil] Return nil if cannot extract sha1 hash, otherwise the value will be returned.
-  attr_accessor :signature
-
-  # Check whether or not this apk is verified
-  # @return [Boolean] Return true if this apk is verified, otherwise false.
-  attr_accessor :verified
-  alias verified? verified
+  # The trusted signature lineage. The first element is the same to the signing signature of the apk file.
+  # @return [Array<String>] empty if it's unsigned.
+  attr_reader :trusted_signature_lineage
 
   # Check whether or not this apk is a test mode
   # @return [Boolean] Return true if this apk is a test mode, otherwise false.
@@ -84,6 +80,21 @@ class AndroidApk
   # @deprecated because a file might be moved/removed
   # @return [String] Return a file path of this apk file
   attr_accessor :filepath
+
+  # The SHA-1 signature of this apk
+  # @deprecated
+  # @return [String, nil] Return nil if cannot extract sha1 hash, otherwise the value will be returned.
+  def signature
+    trusted_signature_lineage[0]
+  end
+
+  # Check whether or not this apk is verified
+  # @deprecated
+  # @return [Boolean] Return true if this apk is verified, otherwise false.
+  def verified
+    (trusted_signature_lineage&.size || 0).positive?
+  end
+  alias verified? verified
 
   NOT_ALLOW_DUPLICATE_TAG_NAMES = %w(
     application
@@ -104,6 +115,7 @@ class AndroidApk
   SUPPORTED_DPI_NAMES = DPI_TO_NAME_MAP.values.freeze
 
   module Reason
+    # @deprecated this is the same to Unsigned
     UNVERIFIED = :unverified
     TEST_ONLY = :test_only
     UNSIGNED = :unsigned
@@ -116,6 +128,7 @@ class AndroidApk
   # @raise [AndroidApk::ApkFileNotFoundError] if the filepath doesn't exist
   # @raise [AndroidApk::UnacceptableApkError] if the apk file is not acceptable by commands like aapt
   # @raise [AndroidApk::AndroidManifestValidateError] if the apk contains invalid AndroidManifest.xml but only when we can identify why it's invalid.
+  # rubocop:disable Metrics/AbcSize
   def self.analyze(filepath)
     raise ApkFileNotFoundError, "an apk file is required to analyze." unless File.exist?(filepath)
 
@@ -178,13 +191,19 @@ class AndroidApk
       DPI_TO_NAME_MAP[dpi] || DEFAULT_RESOURCE_CONFIG
     end.merge(icons_in_arsc)
 
-    read_signature(apk, filepath)
+    apk.instance_variable_set(
+      :@trusted_signature_lineage,
+      ::AndroidApk::SignatureVerifier.verify(
+        filepath: filepath,
+        target_sdk_version: apk.target_sdk_version
+      )
+    )
 
     return apk
   end
+  # rubocop:enable Metrics/AbcSize
 
   def initialize
-    self.verified = false
     self.test_only = false
   end
 
@@ -424,36 +443,6 @@ class AndroidApk
   # @raise [AndroidManifestValidateError] if a key is found in (see NOT_ALLOW_DUPLICATE_TAG_NAMES)
   def self.reject_illegal_duplicated_key!(key)
     raise AndroidManifestValidateError, key if NOT_ALLOW_DUPLICATE_TAG_NAMES.include?(key)
-  end
-
-  def self.read_signature(apk, filepath)
-    # Use target_sdk_version as min sdk version!
-    # Because some of apks are signed by only v2 scheme even though they have 23 and lower min sdk version
-    # The output of the single signing contins Signer #1 but multiple signing a.k.a key rotation just print Signer; It means no #1 prefix.
-    print_certs_command = "apksigner verify --min-sdk-version=#{apk.target_sdk_version} --print-certs #{filepath.shellescape} | grep 'Signer ' | grep 'SHA-1'"
-    certs_hunk, _, exit_status = Open3.capture3(print_certs_command)
-
-    apk.verified = exit_status.success?
-
-    if !exit_status.success? || certs_hunk.nil?
-      # For RSA or DSA encryption
-      print_certs_command = "unzip -p #{filepath.shellescape} META-INF/*.RSA META-INF/*.DSA | openssl pkcs7 -inform DER -text -print_certs | keytool -printcert | grep SHA1:"
-      certs_hunk, _, exit_status = Open3.capture3(print_certs_command)
-    end
-
-    if !exit_status.success? || certs_hunk.nil?
-      # Use a previous method as a fallback just in case
-      print_certs_command = "unzip -p #{filepath.shellescape} META-INF/*.RSA META-INF/*.DSA | keytool -printcert | grep SHA1:"
-      certs_hunk, _, exit_status = Open3.capture3(print_certs_command)
-    end
-
-    if exit_status.success? && !certs_hunk.nil?
-      signatures = certs_hunk.scan(/(?:[0-9a-zA-Z]{2}:?){20}/)
-      # The first seen signer will be the final signer of the apk file.
-      apk.signature = signatures[0].delete(":").downcase
-    else
-      apk.signature = nil # make sure being nil
-    end
   end
 
   # @return [AndroidApk::Xmltree, NilClass]

--- a/lib/android_apk/error.rb
+++ b/lib/android_apk/error.rb
@@ -11,4 +11,7 @@ class AndroidApk
       super("duplicates of #{tag} tag in AndroidManifest.xml are invalid.")
     end
   end
+
+  class ApkSignerExecutionError < Error; end
+  class ParsingSignatureError < Error; end
 end

--- a/lib/android_apk/signature_verifier.rb
+++ b/lib/android_apk/signature_verifier.rb
@@ -30,7 +30,7 @@ class AndroidApk
         end
 
         # The output of the single signing contains Signer #1 but multiple signing a.k.a key rotation just print Signer; It means no #1 prefix.
-        sha1_signatures = (stdout || "").split("\n")
+        sha1_signatures = stdout.split("\n")
           .filter { |l| l.index("Signer ") && l.index("SHA-1 digest") }
           .flat_map { |l| l.scan(SHA1_CAPTURE_REGEX) }
           .map { |sig| sig.delete(":").downcase }

--- a/lib/android_apk/signature_verifier.rb
+++ b/lib/android_apk/signature_verifier.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class AndroidApk
+  module SignatureVerifier
+    SHA1_CAPTURE_REGEX = /(?:[0-9a-zA-Z]{2}:?){20}/.freeze
+
+    class << self
+      # @param filepath [String] an apk filepath (must exist)
+      # @param target_sdk_version [Integer, String] its target sdk version
+      # @return [Array<String>] a signing signature of an apk file with its lineage. Returns an empty array if it's unsigned.
+      def verify(filepath:, target_sdk_version:)
+        # Use target_sdk_version as min sdk version!
+        # Because some of apks are signed by only v2 scheme even though they have 23 and lower min sdk version
+        #
+        # Don't add -v because it will print pub keys too.
+        args = [
+          "apksigner",
+          "verify",
+          "--min-sdk-version",
+          target_sdk_version.to_s,
+          "--print-certs",
+          filepath
+        ]
+        stdout, stderr, exit_status = Open3.capture3(*args)
+
+        unless exit_status.success?
+          return [] if stderr.downcase.include?("does not verify")
+
+          raise AndroidApk::ApkSignerExecutionError, "this file is a malformed apk"
+        end
+
+        # The output of the single signing contains Signer #1 but multiple signing a.k.a key rotation just print Signer; It means no #1 prefix.
+        sha1_signatures = (stdout || "").split("\n")
+          .filter { |l| l.index("Signer ") && l.index("SHA-1 digest") }
+          .flat_map { |l| l.scan(SHA1_CAPTURE_REGEX) }
+          .map { |sig| sig.delete(":").downcase }
+
+        raise AndroidApk::ParsingSignatureError, "the parser cannot get sha1 signatures" if sha1_signatures.empty?
+
+        sha1_signatures
+      end
+    end
+  end
+end

--- a/spec/android_apk/signature_verifier_spec.rb
+++ b/spec/android_apk/signature_verifier_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+describe AndroidApk::SignatureVerifier do
+  describe "#verify" do
+    subject { AndroidApk::SignatureVerifier.verify(filepath: apk_filepath, target_sdk_version: 32) }
+
+    context "if an apk is signature v3" do
+      let(:apk_filepath) { File.join(FIXTURE_DIR, "signatures", "signature-v3", "app-rotated.apk") }
+
+      it "returns the signature trust lineage whose 1st element is the signing signature" do
+        expect(subject).to match_array(%w(e9d0dd023bdab7fae9479d1ecbb3275e0fccac20 eb6cbb57f091e97d614cdc773aa2efc66a39a818))
+      end
+    end
+
+    context "if an apk is not signed" do
+      let(:apk_filepath) { File.join(FIXTURE_DIR, "other", "unsigned.apk") }
+
+      it "returns an empty array" do
+        expect(subject).to be_empty
+      end
+    end
+
+    context "if an apk is malformed" do
+      let(:apk_filepath) { File.join(FIXTURE_DIR, ".gitignore") }
+
+      it "raises ApkSignerExecutionError" do
+        expect { subject }.to raise_error(AndroidApk::ApkSignerExecutionError, "this file is a malformed apk")
+      end
+    end
+
+    %w(rsa dsa).each do |sig_method|
+      context "signed with #{sig_method}" do
+        let(:signing) { sig_method }
+        let(:signature) do
+          {
+            "rsa" => "4ad4e4376face4e441a3b8802363a7f6c6b458ab",
+            "dsa" => "6a2dd3e16a3f05fc219f914734374065985273b3"
+          }[signing]
+        end
+
+        %w(14 24).each do |sdk|
+          context "in apks-#{sdk}" do
+            let(:min_sdk) { sdk }
+
+            [
+              [true, true],
+              [true, false],
+              [false, true]
+            ].each do |v1, v2|
+              context "v1 signed? == #{v1} and v2 signed? == #{v2}" do
+                let(:v1_enabled) { v1 }
+                let(:v2_enabled) { v2 }
+
+                let(:apk_filepath) { File.join(FIXTURE_DIR, "signatures", "apks-#{min_sdk}-v1-#{v1_enabled}-v2-#{v2_enabled}/#{signing}/app-#{signing}.apk") }
+
+                it { expect(subject).to match_array([signature]) }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/android_apk_spec.rb
+++ b/spec/android_apk_spec.rb
@@ -180,14 +180,6 @@ describe "AndroidApk" do
         let(:apk_filepath) { File.join(FIXTURE_DIR, "signatures", "signature-v3", "app-rotated.apk") }
 
         include_examples :analyzable
-
-        it "should expose the signature" do
-          expect(subject.signature).to eq("e9d0dd023bdab7fae9479d1ecbb3275e0fccac20")
-
-          compared_apk_filepath = File.join(FIXTURE_DIR, "signatures", "signature-v3", "app-new.apk")
-
-          expect(subject.signature).to eq(AndroidApk.analyze(compared_apk_filepath).signature)
-        end
       end
 
       describe "resource aware specs" do
@@ -328,45 +320,6 @@ describe "AndroidApk" do
                   it { expect(subject).not_to be_adaptive_icon }
                   it { expect(subject).not_to be_backward_compatible_adaptive_icon }
                   it { expect(subject).to be_installable }
-                end
-              end
-            end
-          end
-        end
-      end
-
-      describe "signature aware specs" do
-        let(:signatures) do
-          {
-            "rsa" => "4ad4e4376face4e441a3b8802363a7f6c6b458ab",
-            "dsa" => "6a2dd3e16a3f05fc219f914734374065985273b3"
-          }
-        end
-
-        let(:apk_filepath) { File.join(FIXTURE_DIR, "signatures", "apks-#{min_sdk}-v1-#{v1_enabled}-v2-#{v2_enabled}/#{signing}/app-#{signing}.apk") }
-
-        %w(rsa dsa).each do |sig_method|
-          context "signed with #{sig_method}" do
-            let(:signing) { sig_method }
-            let(:signature) { signatures[signing] }
-
-            %w(14 24).each do |sdk|
-              context "in apks-#{sdk}" do
-                let(:min_sdk) { sdk }
-
-                [
-                  [true, true],
-                  [true, false],
-                  [false, true]
-                ].each do |v1, v2|
-                  context "v1 signed? == #{v1} and v2 signed? == #{v2}" do
-                    let(:v1_enabled) { v1 }
-                    let(:v2_enabled) { v2 }
-
-                    it { expect(subject.signature).to eq(signature) }
-                    it { expect(subject).to be_signed }
-                    it { expect(subject).to be_installable }
-                  end
                 end
               end
             end


### PR DESCRIPTION
AndroidApk have to return a trusted signature lineage but not only a signing signature.

This PR also removes legacy fallbacks because it may cause unexpected results if an apk has been signed twice or more. apksigner's outputs are the most reliable by the way.