### PR TITLE
Bumpup build-tools version to 35.0.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,7 +36,7 @@ jobs:
         java-version:
           - 11
         buildtools-version:
-          - 34.0.0
+          - 35.0.0
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/lib/android_apk/aapt2/dump_badging.rb
+++ b/lib/android_apk/aapt2/dump_badging.rb
@@ -41,7 +41,7 @@ class AndroidApk
 
         # @return [String, NilClass] an application's min sdk version. The format is an integer string which is defined in AndroidManifest.xml. Legacy apk may return nil.
         def min_sdk_version
-          @parsed_variables["sdkVersion"]
+          @parsed_variables["minSdkVersion"]
         end
 
         # @return [String, NilClass] an application's target sdk version. The format is an integer string which is defined in AndroidManifest.xml. Legacy apk may return nil.
@@ -88,13 +88,13 @@ class AndroidApk
         application
         application-label
         package
-        sdkVersion
+        minSdkVersion
         targetSdkVersion
       ).freeze
 
       NOT_ALLOW_DUPLICATE_TAG_NAMES = %w(
         application
-        sdkVersion
+        minSdkVersion
         targetSdkVersion
       ).freeze
 


### PR DESCRIPTION
New Android SDK Build-Tools was coming so we changed to follow the version.

This PR has only one change caused by the difference output of `aapt2 dump badging` command.
The minimum SDK version was reported as "sdkVersion" in a previous version(34.0.0).
But, the new version(35.0.0) is reported as "minSdkVersion".

```
# 34.0.0
sdkVersion:'8'

# 35.0.0
minSdkVersion:'8'
```