### PR TITLE
fix some errors in Actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix: # Use as the parameter injection
         java-version:
-          - 11
+          - 17
         buildtools-version:
           - 35.0.0
     timeout-minutes: 20

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,6 +40,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - run: |
+          sudo apt-get update
+          sudo apt-get install imagemagick
       - uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf
         with:
           bundler-cache: true


### PR DESCRIPTION
Update Java because GitHub actions always fail.

That fail contains two reasons:

1. `cmdline-tools; 7.0` may require Java17. We need to update JDK.

```
/usr/local/lib/android/sdk/cmdline-tools/latest/bin/sdkmanager cmdline-tools;7.0
Error: LinkageError occurred while loading main class com.android.sdklib.tool.sdkmanager.SdkManagerCli
	java.lang.UnsupportedClassVersionError: com/android/sdklib/tool/sdkmanager/SdkManagerCli has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
/home/runner/work/_actions/android-actions/setup-android/v2/dist/index.js:2348
                error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
                        ^

Error: The process '/usr/local/lib/android/sdk/cmdline-tools/latest/bin/sdkmanager' failed with exit code 1
    at ExecState._setResult (/home/runner/work/_actions/android-actions/setup-android/v2/dist/index.js:2348:25)
    at ExecState.CheckComplete (/home/runner/work/_actions/android-actions/setup-android/v2/dist/index.js:2331:18)
    at ChildProcess.<anonymous> (/home/runner/work/_actions/android-actions/setup-android/v2/dist/index.js:2225:27)
    at ChildProcess.emit (node:events:519:28)
    at maybeClose (node:internal/child_process:1105:[16](https://github.com/DeployGate/android_apk/actions/runs/12366230713/job/34512572367#step:5:18))
    at ChildProcess._handle.onexit (node:internal/child_process:305:5)
```

2. Some specs fail because ImageMagick is unavailable in runner.


