### PR TITLE
Use 'ubuntu-2204' image instead of 'ubuntu-latest'

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: >
       github.actor == 'dependabot[bot]'
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         task:
@@ -30,7 +30,7 @@ jobs:
       - run: bundle exec rake ${{ matrix.task }}
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix: # Use as the parameter injection
         java-version:


### PR DESCRIPTION
From 2024/12, label of 'ubuntu-latest' image changed version from '2204' to ’2404'.
ref. https://github.com/actions/runner-images/issues/10636

'ubuntu-2404' image doesn't contain ImageMagick package.
And also that image caused some failure, so we back to using 'ubuntu-2204' image.