### PR TITLE
Update buildtools to 35.0.1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,7 +36,7 @@ jobs:
         java-version:
           - 11
         buildtools-version:
-          - 35.0.0
+          - 35.0.1
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
The new version of build tools (v35.0.1) was released.
We need to check compatibility and update it.