### PR TITLE
bump up library version to 1.10.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    android_apk (1.9.0)
+    android_apk (1.10.0)
       rubyzip (~> 2.3.0)
 
 GEM

--- a/lib/android_apk/version.rb
+++ b/lib/android_apk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class AndroidApk
-  VERSION = "1.9.0"
+  VERSION = "1.10.0"
 end


### PR DESCRIPTION
Prepare for the release of the new version.

v1.10.0 includes the following changes:
- #210 